### PR TITLE
Fixed tests conditional validations

### DIFF
--- a/src/assets/utils/formatFormData.js
+++ b/src/assets/utils/formatFormData.js
@@ -10,13 +10,13 @@ export const formatData = (data) => {
   const { testStatus, testResults } = data;
   const { resultsSwab, resultsAnti } = testResults;
   const testData = {
-    test_none: false,
-    test_tried: false,
-    test_no_result: false,
-    test_swab_neg: false,
-    test_swab_pos: false,
-    test_anti_neg: false,
-    test_anti_pos: false,
+    test_none: null,
+    test_tried: null,
+    test_no_result: null,
+    test_swab_neg: null,
+    test_swab_pos: null,
+    test_anti_neg: null,
+    test_anti_pos: null,
   };
   const newKeyVal = Object.entries(testData)
     .filter(

--- a/src/assets/utils/formatFormData.js
+++ b/src/assets/utils/formatFormData.js
@@ -7,7 +7,8 @@ export const formatBody = ({ reported_date, ...rest }) => ({
 });
 
 export const formatData = (data) => {
-  const { testStatus, resultsSwab, resultsAnti } = data;
+  const { testStatus, testResults } = data;
+  const { resultsSwab, resultsAnti } = testResults;
   const testData = {
     test_none: false,
     test_tried: false,
@@ -17,7 +18,6 @@ export const formatData = (data) => {
     test_anti_neg: false,
     test_anti_pos: false,
   };
-
   const newKeyVal = Object.entries(testData)
     .filter(
       ([key]) =>
@@ -34,7 +34,7 @@ export const formatData = (data) => {
     ...newKeyVal,
   };
   delete newTestData["testStatus"];
-  delete newTestData["resultsSwab"];
-  delete newTestData["resultsAnti"];
+  delete newTestData["testResults"];
+
   return newTestData;
 };

--- a/src/containers/reportformpage/ReportFormPage.js
+++ b/src/containers/reportformpage/ReportFormPage.js
@@ -262,10 +262,14 @@ class ReportFormPage extends Component {
                 // Bug: validation fires before setFieldValue update. Requires two clicks of options.
                 onChange={(e) => {
                   handleChange(e);
-                  setFieldValue("testResults", {
-                    resultsSwab: null,
-                    resultsAnti: null,
-                  });
+                  setFieldValue(
+                    "testResults",
+                    {
+                      resultsSwab: null,
+                      resultsAnti: null,
+                    },
+                    false
+                  );
                 }}
                 options={[
                   { label: "I've not sought testing", value: "test_none" },

--- a/src/containers/reportformpage/ReportFormPage.js
+++ b/src/containers/reportformpage/ReportFormPage.js
@@ -136,7 +136,14 @@ class ReportFormPage extends Component {
             });
           }}
         >
-          {({ values, isSumbitting, touched, errors, handleChange }) => (
+          {({
+            values,
+            isSumbitting,
+            touched,
+            errors,
+            handleChange,
+            setFieldValue,
+          }) => (
             <Form className="form_container">
               <h3 className="shared_header">Clinical Setting</h3>
 
@@ -252,6 +259,14 @@ class ReportFormPage extends Component {
                 as={MyRadioGroup}
                 name="testStatus"
                 legend="Test Status"
+                // Bug: validation fires before setFieldValue update. Requires two clicks of options.
+                onChange={(e) => {
+                  handleChange(e);
+                  setFieldValue("testResults", {
+                    resultsSwab: null,
+                    resultsAnti: null,
+                  });
+                }}
                 options={[
                   { label: "I've not sought testing", value: "test_none" },
                   {


### PR DESCRIPTION


## Related Issues

List related Issues:

| https://github.com/codefordayton/floswhistle-pandemic-v2/issues/11 |
| ---- |
|https://github.com/codefordayton/floswhistle-pandemic-v2/issues/15|
|https://github.com/codefordayton/floswhistle-pandemic-v2/issues/16|

## ReportFormPage
- form on ReportFormPage
- validation for form
- data then submitted via form

## Notes - small bug
Related to issue 15, there is a small bug in event sequencing with form validation

**Order of Events:** Choose Tested - received results --> Choose a test results --> switch answer to I've not sought testing, Tried but couldn't get tested, Tested - no result yet, --> validation fires and tells you you need to choose a test result, --> testing results reset, --> switch answer between I've not sought testing, Tried but couldn't get tested, Tested - no result yet, --> validation fires with reset results from first answer switch and is valid