### PR TITLE
header navigation, dashboard/stats/map named results on pages and url

### DIFF
--- a/src/components/header/Header.css
+++ b/src/components/header/Header.css
@@ -1,9 +1,0 @@
-.Header {
-  padding: 2em;
-  text-align: center;
-}
-
-.Header img {
-  max-height: 96px;
-  max-width: 100%;
-}

--- a/src/components/header/Header.js
+++ b/src/components/header/Header.js
@@ -1,14 +1,66 @@
-import React from "react";
-import "./Header.css";
+import React, { Component } from "react";
+import { NavLink } from "react-router-dom";
+import "./Header.scss";
 
-const Header = () => {
-  return (
-    <div className="Header">
-      <a href="/">
-        <img src="/images/floswhistle.png" alt="Flos Whistle" />
-      </a>
-    </div>
-  );
-};
+class Header extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      mobile: false,
+    };
+    this.toggleMobileMenu = this.toggleMobileMenu.bind(this);
+  }
+  toggleMobileMenu() {
+    const { mobile } = this.state;
+    this.setState({
+      mobile: !mobile,
+    });
+  }
+  render() {
+    const { mobile } = this.state;
+    return (
+      <div className="Header">
+        <a href="/" id="Logo">
+          <img src="/images/floswhistle.png" alt="Flos Whistle" />
+        </a>
+        <button
+          onClick={this.toggleMobileMenu}
+          className="Header_Mobile_MenuButton"
+        >
+          {mobile ? (
+            <i className="fas fa-times"></i>
+          ) : (
+            <i className="fas fa-bars"></i>
+          )}
+        </button>
+        <div className="Header_NavLink_Menu">
+          <div
+            className={`Header_NavLink_Container${mobile ? " _Active" : ""}`}
+          >
+            <NavLink
+              exact
+              to="/"
+              className={`Header_NavLink${mobile ? " _Show" : ""}`}
+            >
+              Home
+            </NavLink>
+            <NavLink
+              to="/results"
+              className={`Header_NavLink${mobile ? " _Show" : ""}`}
+            >
+              Results
+            </NavLink>
+            <NavLink
+              to="/download"
+              className={`Header_NavLink${mobile ? " _Show" : ""}`}
+            >
+              Download
+            </NavLink>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
 
 export default Header;

--- a/src/components/header/Header.scss
+++ b/src/components/header/Header.scss
@@ -1,0 +1,124 @@
+.Header {
+  display: flex;
+  flex-direction: row;
+  padding: 0.2rem 0;
+  background-color: white;
+  margin-bottom: 1rem;
+  border-bottom: 2px solid #303a84;
+
+  #Logo {
+    margin-right: auto;
+    margin-left: 1rem;
+  }
+
+  /* react-router-dom active class */
+  .active {
+    color: #57cfed !important;
+    text-decoration: underline !important;
+  }
+
+  img {
+    max-height: 96px;
+    max-width: 100%;
+  }
+
+  .Header_Mobile_MenuButton {
+    display: none;
+  }
+
+  .Header_NavLink_Menu {
+    margin: auto 0.5rem;
+
+    .Header_NavLink {
+      text-decoration: none;
+      color: #303a84;
+      font-size: 1.5rem;
+      margin: 0 0.5rem;
+      font-weight: bold;
+      text-transform: uppercase;
+    }
+  }
+
+  .Header_Mobile_Menu {
+    display: none;
+  }
+
+  @media (hover: hover) {
+    .Header_NavLink:hover {
+      color: #57cfed;
+    }
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .Header {
+    text-align: center;
+    z-index: 2;
+
+    #Logo {
+      margin: auto;
+      z-index: 2;
+    }
+
+    .Header_Mobile_MenuButton {
+      position: absolute;
+      display: block;
+      color: #303a84;
+      background-color: rgba(245, 245, 245, 0.8);
+      width: 3rem;
+      height: 3rem;
+      right: 0;
+      margin-top: 1.6rem;
+      margin-right: 1.5rem;
+      padding: 0.5rem;
+      border: 1px solid #57cfed;
+      border-radius: 0.5rem;
+      z-index: 2;
+
+      i {
+        font-size: 2rem;
+        z-index: 2;
+      }
+    }
+
+    .Header_NavLink_Menu {
+      position: absolute;
+      width: 100%;
+      margin-left: 0;
+      top: -4.4em;
+      z-index: 1;
+
+      ._Active {
+        display: block;
+        transition: 0.7s;
+        transform: translateY(11rem);
+      }
+
+      .Header_NavLink_Container {
+        position: relative;
+        display: flex;
+        flex-direction: column;
+        z-index: 1;
+        height: 9em;
+        padding: 1em;
+        background-color: rgb(255, 255, 255);
+        transition: 0.7s;
+        border-bottom: 2px solid #303a84;
+
+        .Header_NavLink {
+          padding: 0.5rem;
+          visibility: hidden;
+          opacity: 0;
+          transition: 0.2s;
+        }
+
+        ._Show {
+          visibility: visible;
+          opacity: 1;
+          transition: 0.8s;
+          z-index: 1;
+        }
+      }
+    }
+  }
+}

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -19,7 +19,7 @@ function App() {
           <Route exact path="/" component={HomePage} />
           <Route exact path="/pledge" component={ReportPledgePage} />
           <Route exact path="/report" component={ReportFormPage} />
-          <Route exact path="/map" component={Dashboard} />
+          <Route exact path="/results" component={Dashboard} />
           <Route exact path="/thanks" component={ThankYouPage} />
           <Route exact path="/download" component={DownloadPage} />
         </Switch>

--- a/src/containers/homepage/HomePage.js
+++ b/src/containers/homepage/HomePage.js
@@ -8,8 +8,8 @@ const HomePage = (props) => {
     <div className="HomePage">
       <div className="Hero">
         <div className="HeroColumn">
-          <Link className="HeroButton" to="/map">
-            Curious? Check stats
+          <Link className="HeroButton" to="/results">
+            Curious? Check results
           </Link>
           <HashLink className="HeroButton_Scroll" to="#ActionButton">
             Scroll to file report

--- a/src/containers/thankyoupage/ThankYouPage.js
+++ b/src/containers/thankyoupage/ThankYouPage.js
@@ -31,7 +31,7 @@ const ThankYouPage = (props) => {
         </div>
 
         <div className="buttons">
-          <Link to="/map" className="UtilLink">
+          <Link to="/results" className="UtilLink">
             see results dashboard
           </Link>
         </div>


### PR DESCRIPTION
## Related PRs

List related PRs against other branches:

| branch          | PR       |
| --------------- | -------- |
| other_pr_description | # |

## Related Issues

List related Issues:

| link |
| ---- |
|  #62   |

## Todos

- [ ] Tests
- [ ] Documentation

## Deploy Notes

Notes regarding deployment the contained body of work. 

## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.

```sh
commands to test PR
```

## Impacted Areas in Application

List general components of the application that this PR will affect:

- header navigation added including mobile menu
- floswhistle.org/map is now floswhistle.org/results
- all references to stats or dashboard in page content are now "results" and "results dashboard" on ThankYouPage button link.
